### PR TITLE
Config subscription

### DIFF
--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -25,7 +25,29 @@ function addAvailableThemes(config) {
 }
 
 function setTheme(newTheme) {
-  atom.config.set("core.themes", newTheme);
+  atom.config.set('core.themes', newTheme);
+}
+
+// Callback function for observing changes to core.themes
+// This callback will help keep the package and core theme settings consistent
+function configThemesChange(newTheme) {
+  if (!night) {
+      if (manualNight) {
+        atom.config.set('night-light.night.ui', newTheme[0]);
+        atom.config.set('night-light.night.syntax', newTheme[1]);
+      } else {
+        atom.config.set('night-light.day.ui', newTheme[0]);
+        atom.config.set('night-light.day.syntax', newTheme[1]);
+      }
+  } else {
+    if (manualDay) {
+      atom.config.set('night-light.day.ui', newTheme[0]);
+      atom.config.set('night-light.day.syntax', newTheme[1]);
+    } else {
+      atom.config.set('night-light.night.ui', newTheme[0]);
+      atom.config.set('night-light.night.syntax', newTheme[1]);
+    }
+  }
 }
 
 var sunrise = null;
@@ -49,7 +71,7 @@ export default {
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'night-light:toggle': () => this.toggle()
     }));
-
+    this.subscriptions.add(atom.config.observe('core.themes', updatePackageThemes));
     this.tick = this.tick.bind(this);
     setTimeout(this.tick, 500); // for initialization
     setInterval(this.tick, 60000);

--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -10,7 +10,7 @@ function getNightThemes() {
 function getDayThemes() {
   return [atom.config.get("night-light.day.ui"), atom.config.get("night-light.day.syntax")];
 }
-
+// middleware for adding installed themes to package config dropdown menus
 function addAvailableThemes(config) {
   atom.themes.getLoadedThemeNames().map((theme) => {
     if(/.*-ui$/.test(theme)) {
@@ -23,13 +23,15 @@ function addAvailableThemes(config) {
   });
   return config;
 }
-
+// Helper function for changing editor themes: uses format ["ui", "syntax"]
 function setTheme(newTheme) {
   atom.config.set('core.themes', newTheme);
 }
 
-// Callback function for observing changes to core.themes
-// This callback will help keep the package and core theme settings consistent
+/* CONFIG CALLBACK FUNCTIONS
+This callback will help keep the package and core theme settings consistent
+*/
+// callback for observing core.themes
 function coreThemesChange(newTheme) {
   var dayThemes = getDayThemes();
   var nightThemes = getNightThemes();
@@ -56,7 +58,7 @@ function coreThemesChange(newTheme) {
     }
   }
 }
-
+// callback for observing night-light.day
 function packageDayThemesChange(newTheme) {
   var theme = [newTheme.ui, newTheme.syntax]
   if (!night) {
@@ -66,7 +68,7 @@ function packageDayThemesChange(newTheme) {
       setTheme(theme);
     }
 }
-
+// callback for observing night-light.night
 function packageNightThemesChange(newTheme) {
   var theme = [newTheme.ui, newTheme.syntax]
   if (night) {
@@ -77,7 +79,7 @@ function packageNightThemesChange(newTheme) {
   }
 }
 
-
+// global package variables
 var sunrise = null;
 var sunset = null;
 var lat = null;
@@ -87,6 +89,7 @@ var manualNight = false;
 var manualDay = false;
 var lastRefresh = 0;
 
+// main module
 export default {
 
   config: addAvailableThemes(require('./config.json')),
@@ -116,7 +119,7 @@ export default {
   serialize() {
     return;
   },
-
+  // manually switch between appearances for different times of day
   toggle() {
     if (night) {
       manualDay = !manualDay;
@@ -126,7 +129,7 @@ export default {
       manualNight ? setTheme(getNightThemes()) : setTheme(getDayThemes());
     }
   },
-
+  // Check lat/lng or get the pre-configured coordinates
   updateLocation() {
     // Returns a promise so updateSunriseSunset() will only run after updateLocation finishes
     return new Promise(function(resolve, reject) {
@@ -162,7 +165,7 @@ export default {
         }
       });
   },
-
+  // Get sunrise and sunset times based on the given lat/lng
   updateSunriseSunsetTimes(location) {
     if(atom.config.get('night-light.schedule.auto')) {
       noonToday = new Date().setHours("12");

--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -30,25 +30,53 @@ function setTheme(newTheme) {
 
 // Callback function for observing changes to core.themes
 // This callback will help keep the package and core theme settings consistent
-function configThemesChange(newTheme) {
+function coreThemesChange(newTheme) {
+  var dayThemes = getDayThemes();
+  var nightThemes = getNightThemes();
   if (!night) {
       if (manualNight) {
+        if(newTheme == nightThemes) return;
         atom.config.set('night-light.night.ui', newTheme[0]);
         atom.config.set('night-light.night.syntax', newTheme[1]);
+
       } else {
+        if(newTheme == dayThemes) return;
         atom.config.set('night-light.day.ui', newTheme[0]);
         atom.config.set('night-light.day.syntax', newTheme[1]);
       }
   } else {
     if (manualDay) {
+      if(newTheme == dayThemes) return;
       atom.config.set('night-light.day.ui', newTheme[0]);
       atom.config.set('night-light.day.syntax', newTheme[1]);
     } else {
+      if(newTheme == nightThemes) return;
       atom.config.set('night-light.night.ui', newTheme[0]);
       atom.config.set('night-light.night.syntax', newTheme[1]);
     }
   }
 }
+
+function packageDayThemesChange(newTheme) {
+  var theme = [newTheme.ui, newTheme.syntax]
+  if (!night) {
+    if (manualNight) return;
+    setTheme(theme);
+  } else if (night && manualDay) {
+      setTheme(theme);
+    }
+}
+
+function packageNightThemesChange(newTheme) {
+  var theme = [newTheme.ui, newTheme.syntax]
+  if (night) {
+    if (manualDay) return;
+    setTheme(theme);
+  } else if (!night && manualNight) {
+    setTheme(theme);
+  }
+}
+
 
 var sunrise = null;
 var sunset = null;
@@ -70,8 +98,12 @@ export default {
     // Register the toggle command
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'night-light:toggle': () => this.toggle()
-    }));
-    this.subscriptions.add(atom.config.observe('core.themes', updatePackageThemes));
+    }),
+      atom.config.observe('core.themes', coreThemesChange),
+      atom.config.observe('night-light.day', packageDayThemesChange),
+      atom.config.observe('night-light.night', packageNightThemesChange)
+    );
+
     this.tick = this.tick.bind(this);
     setTimeout(this.tick, 500); // for initialization
     setInterval(this.tick, 60000);

--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -10,6 +10,9 @@ function getNightThemes() {
 function getDayThemes() {
   return [atom.config.get("night-light.day.ui"), atom.config.get("night-light.day.syntax")];
 }
+function equal(theme1, theme2) {
+  return (theme1[1] == theme2[1]) && (theme1[0] == theme2[0]);
+}
 // middleware for adding installed themes to package config dropdown menus
 function addAvailableThemes(config) {
   atom.themes.getLoadedThemeNames().map((theme) => {
@@ -31,33 +34,6 @@ function setTheme(newTheme) {
 /* CONFIG CALLBACK FUNCTIONS
 This callback will help keep the package and core theme settings consistent
 */
-// callback for observing core.themes
-function coreThemesChange(newTheme) {
-  var dayThemes = getDayThemes();
-  var nightThemes = getNightThemes();
-  if (!night) {
-      if (manualNight) {
-        if(newTheme == nightThemes) return;
-        atom.config.set('night-light.night.ui', newTheme[0]);
-        atom.config.set('night-light.night.syntax', newTheme[1]);
-
-      } else {
-        if(newTheme == dayThemes) return;
-        atom.config.set('night-light.day.ui', newTheme[0]);
-        atom.config.set('night-light.day.syntax', newTheme[1]);
-      }
-  } else {
-    if (manualDay) {
-      if(newTheme == dayThemes) return;
-      atom.config.set('night-light.day.ui', newTheme[0]);
-      atom.config.set('night-light.day.syntax', newTheme[1]);
-    } else {
-      if(newTheme == nightThemes) return;
-      atom.config.set('night-light.night.ui', newTheme[0]);
-      atom.config.set('night-light.night.syntax', newTheme[1]);
-    }
-  }
-}
 // callback for observing night-light.day
 function packageDayThemesChange(newTheme) {
   var theme = [newTheme.ui, newTheme.syntax]
@@ -102,7 +78,6 @@ export default {
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'night-light:toggle': () => this.toggle()
     }),
-      atom.config.observe('core.themes', coreThemesChange),
       atom.config.observe('night-light.day', packageDayThemesChange),
       atom.config.observe('night-light.night', packageNightThemesChange)
     );


### PR DESCRIPTION
Observe package theme settings and update the editor themes when the package settings change. 
* If a user changes the daytime themes during the day (or when daytime is manually toggled), the editor will update to the newly specified themes.
* If a user changes the nighttime themes during the night (or when nighttime is manually toggled), the editor will update to the newly specified themes.
* If a user changes the daytime themes during the night (or vise versa), then the editor will **not** change themes right away because it is not the proper time.