### PR TITLE
Remove alert for ENOENT error

### DIFF
--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -156,12 +156,6 @@ export default {
             packageState.lng = json.location.lng;
             resolve(json.location);
           } else if (error) {
-            atom.notifications.addWarning("night-light: There was an error with automatically updating your location",
-            {
-              'detail': "Checking your internet connection usually fixes the problem.\n\nNo worries though! In the meantime, we'll use the latitude/longitude you've specified in the Night-Light package settings.",
-              'description': "Error Code: "+ error.code,
-              'dismissable': true
-            });
             // No worries, just use default sunrise/sunset
             packageState.lat = atom.config.get('night-light.location.lat');
             packageState.lng = atom.config.get('night-light.location.lng');


### PR DESCRIPTION
I noticed the alert was happening all too frequently, so I've decided to modify how the package uses alerts. For now, I've just simply removed the alert entirely. 