### PR TITLE
Add theme data to serialization

### DIFF
--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -4,6 +4,7 @@ import { CompositeDisposable } from 'atom';
 
 const MAPS_API = 'https://maps.googleapis.com/maps/api/browserlocation/json?browser=chromium&sensor=true'
 
+// Theme helpers
 function getNightThemes() {
   return [atom.config.get("night-light.night.ui"), atom.config.get("night-light.night.syntax")];
 }
@@ -13,7 +14,7 @@ function getDayThemes() {
 function equal(theme1, theme2) {
   return (theme1[1] == theme2[1]) && (theme1[0] == theme2[0]);
 }
-// middleware for adding installed themes to package config dropdown menus
+// Middleware function for adding installed themes to package config dropdown menus
 function addAvailableThemes(config) {
   atom.themes.getLoadedThemeNames().map((theme) => {
     if(/.*-ui$/.test(theme)) {
@@ -28,16 +29,13 @@ function addAvailableThemes(config) {
 }
 // Helper function for changing editor themes: uses format ["ui", "syntax"]
 function setTheme(newTheme) {
-  console.log("setTheme");
   atom.config.set('core.themes', newTheme);
 }
 
-/** CONFIG CALLBACK FUNCTIONS
-* These callbacks will help keep the package and core theme settings consistent
-*/
+// Config callback functions
+// These callbacks will help keep the package and core theme settings consistent
 // callback for observing night-light.day
 function packageDayThemesChange(newTheme) {
-  console.log("packageDayThemesChange");
   var theme = [newTheme.ui, newTheme.syntax]
   if (!packageState.night) {
     if (packageState.manualNight) return;
@@ -48,7 +46,6 @@ function packageDayThemesChange(newTheme) {
 }
 // callback for observing night-light.night
 function packageNightThemesChange(newTheme) {
-    console.log("packageNightThemesChange");
   var theme = [newTheme.ui, newTheme.syntax]
   if (packageState.night) {
     if (packageState.manualDay) return;
@@ -57,7 +54,6 @@ function packageNightThemesChange(newTheme) {
     setTheme(theme);
   }
 }
-
 // callback for observing night-light.location
 function locationChange({newValue: {auto,lat,lng}}) {
   if (!auto) {
@@ -66,6 +62,7 @@ function locationChange({newValue: {auto,lat,lng}}) {
     main.updateLocation().then(main.updateSunriseSunsetTimes).then(main.checkThemes);
   }
 }
+
 // Package State
 let packageState = {
   sunrise: null,
@@ -84,16 +81,20 @@ export default {
   subscriptions: null,
 
   activate(state) {
-    console.log("State: ");
-    console.log(state);
     if (state) {
       for (var key in state) {
-        console.log(key)
-        packageState[key] = state[key];
+        if(key === 'dayThemes') {
+          atom.config.set('night-light.day.ui',state.dayThemes[0])
+          atom.config.set('night-light.day.syntax',state.dayThemes[1])
+        } else if(key === 'nightThemes') {
+          atom.config.set('night-light.night.ui',state.nightThemes[0])
+          atom.config.set('night-light.night.syntax',state.nightThemes[1])
+        } else {
+          packageState[key] = state[key];
+        }
       }
-
     }
-    console.log(packageState)
+
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable();
     // Register the toggle command
@@ -106,7 +107,6 @@ export default {
     );
 
     this.tick = this.tick.bind(this);
-
     setTimeout(this.tick, 500); // for initialization
     setInterval(this.tick, 60000);
   },
@@ -116,7 +116,6 @@ export default {
   },
 
   serialize() {
-    console.log("serializing...");
     var serialized = {
       sunrise,
       sunset,
@@ -127,7 +126,8 @@ export default {
       manualDay,
       lastRefresh
     } = packageState
-    console.log(serialized)
+    serialized.dayThemes = getDayThemes();
+    serialized.nightThemes = getNightThemes();
     return serialized;
   },
   // manually switch between appearances for different times of day
@@ -165,8 +165,8 @@ export default {
         } else {
           // No worries, just use default sunrise/sunset
           packageState.lat = atom.config.get('night-light.location.lat');
-          lng = atom.config.get('night-light.location.lng');
-          resolve({lat: packageState.lat, lng:lng});
+          packageState.lng = atom.config.get('night-light.location.lng');
+          resolve({lat: packageState.lat, lng:packageState.lng});
         }
       });
   },
@@ -206,7 +206,6 @@ export default {
     } else if (now >= times.sunrise) {
       packageState.night = false;
       packageState.manualDay = false;
-      console.log(packageState.manualNight)
       if (packageState.manualNight) return;
       setTheme(getDayThemes());
     }


### PR DESCRIPTION
This PR incorporates package theme data to the serialized state. This will be a backup in case the package config data doesn't persist across the update. 