### PR TITLE
Update config logic

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 	"night": {
 		"title": "Nighttime Appearance",
 		"type": "object",
@@ -9,7 +9,12 @@
 				"description": "UI theme to use at night.",
 				"type": "string",
 				"default": "one-dark-ui",
-				"enum": [],
+				"enum": [
+					"atom-dark-ui", 
+					"atom-light-ui", 
+					"one-dark-ui", 
+					"one-light-ui"
+				],
 				"order": 1
 			},
 			"syntax": {
@@ -17,7 +22,16 @@
 				"description": "Syntax theme to use at night.",
 				"type": "string",
 				"default": "one-dark-syntax",
-				"enum": [],
+				"enum": [
+					"atom-dark-syntax", 
+					"atom-light-syntax", 
+					"one-dark-syntax", 
+					"one-light-syntax",
+					"solarized-dark-syntax",
+					"solarized-light-syntax",
+					"base16-tomorrow-dark-theme",
+					"base16-tomorrow-light-theme"
+				],
 				"order": 2
 			}
 		}
@@ -32,8 +46,12 @@
 				"description": "UI theme to use during the day.",
 				"type": "string",
 				"default": "one-light-ui",
-				"pattern": "/.*-ui$/",
-				"enum": [],
+				"enum": [
+					"atom-dark-ui", 
+					"atom-light-ui", 
+					"one-dark-ui", 
+					"one-light-ui"
+				],
 				"order": 1
 			},
 			"syntax": {
@@ -41,7 +59,16 @@
 				"description": "Syntax theme to use during the day.",
 				"type": "string",
 				"default": "one-light-syntax",
-				"enum": [],
+				"enum": [
+					"atom-dark-syntax", 
+					"atom-light-syntax", 
+					"one-dark-syntax", 
+					"one-light-syntax",
+					"solarized-dark-syntax",
+					"solarized-light-syntax",
+					"base16-tomorrow-dark-theme",
+					"base16-tomorrow-light-theme"
+				],
 				"order": 2
 			}
 		}

--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -16,6 +16,7 @@ function equal(theme1, theme2) {
 }
 // Middleware function for adding installed themes to package config dropdown menus
 function addAvailableThemes(config) {
+  console.log(config)
   atom.themes.getLoadedThemeNames().map((theme) => {
     if(/.*-ui$/.test(theme)) {
       config.night.properties.ui.enum.push(theme);
@@ -76,8 +77,8 @@ let packageState = {
 }
 
 // main module
-export default {
-  config: addAvailableThemes(require('./config.json')),
+let main = {
+  config: addAvailableThemes(require('./config.js')),
   subscriptions: null,
 
   activate(state) {
@@ -226,3 +227,5 @@ export default {
     }
   }
 };
+
+export default main;

--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -16,14 +16,17 @@ function equal(theme1, theme2) {
 }
 // Middleware function for adding installed themes to package config dropdown menus
 function addAvailableThemes(config) {
-  console.log(config)
-  atom.themes.getLoadedThemeNames().map((theme) => {
-    if(/.*-ui$/.test(theme)) {
-      config.night.properties.ui.enum.push(theme);
-      config.day.properties.ui.enum.push(theme);
-    } else if (/.*syntax$/.test(theme)) {
-      config.night.properties.syntax.enum.push(theme);
-      config.day.properties.syntax.enum.push(theme);
+  //console.log(config)
+  atom.themes.getLoadedThemes().map(({bundledPackage,name, metadata: {theme} }) => {
+    if(bundledPackage){ // if it's a default theme, 
+      return // don't add to config (it's already there
+    }
+    if(theme === 'ui') { // Sort loaded UI Themes
+      config.night.properties.ui.enum.push(name);
+      config.day.properties.ui.enum.push(name);
+    } else if (theme === 'syntax') { // Sord loaded syntax themes
+      config.night.properties.syntax.enum.push(name);
+      config.day.properties.syntax.enum.push(name);
     }
   });
   return config;
@@ -94,6 +97,9 @@ let main = {
           packageState[key] = state[key];
         }
       }
+      if(packageState.night) {
+        setTheme(state.nightThemes)
+      } else setTheme(state.dayThemes)
     }
 
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable


### PR DESCRIPTION
* convert `config.json` to a commonJS module in `config.js`
* Change the main module to have the varaible name `main`
* Fix an issue where some themes weren't appearing in the package settings drop-down menus (closes #11)

**This PR unfortunately adds about 10ms of extra activation time from the use of an API Call to `atom.themes.getLoadedThemes()`.** I've minimized the activation time as much as possible by using object destructuring in the function parameter when mapping across the returned list of `Theme` objects. I'll try to look for a better solution in the future, but this may be the best method for now. 