### PR TITLE
Fix undefined reference to geoError function

### DIFF
--- a/lib/night-light.js
+++ b/lib/night-light.js
@@ -151,7 +151,7 @@ let main = {
       if (navigator.geolocation && atom.config.get('night-light.location.auto')) {
           navigator.geolocation.getCurrentPosition(this.geoSuccess, this.geoError)
       } else {
-          geoError();
+          this.geoError();
       }
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "night-light",
+  "version": "1.0.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "suncalc": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.8.0.tgz",
+      "integrity": "sha1-HZiYEJVjB4dQ9JlKlZ5lTYdqy/U="
+    }
+  }
+}


### PR DESCRIPTION
Add the `this` keyword to reference geoError from the proper object

Fixes #15